### PR TITLE
quiz(js): fix output in difference between var, let, const

### DIFF
--- a/contents/javascript-questions.md
+++ b/contents/javascript-questions.md
@@ -1000,7 +1000,7 @@ function foo() {
   console.log(qux); // qux
 }
 
-console.log(bar); // ReferenceError: bar is not defined
+console.log(bar); // undefined
 console.log(baz); // ReferenceError: baz is not defined
 console.log(qux); // ReferenceError: qux is not defined
 ```


### PR DESCRIPTION
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->

Corrected the expected output for the quiz about difference between variables created using **var**, **let** & **const**. 
Expected output was a ReferenceError.
It should be undefined because **var** variables are hoisted to the enclosing function even when they're declared in a nested block scope.